### PR TITLE
Avoid assuming chicken install directory

### DIFF
--- a/bootstrap.scm
+++ b/bootstrap.scm
@@ -1,4 +1,7 @@
-#!/usr/bin/csi -qbw
+#!/bin/sh
+#|
+exec csi -s "$0" "$@"
+|#
 
 (import chicken.string)
 (import chicken.format)

--- a/src/command/build/compiler.scm
+++ b/src/command/build/compiler.scm
@@ -6,6 +6,7 @@
 (import chicken.string)
 (import chicken.format)
 (import chicken.file)
+(import chicken.foreign)
 (import chicken.process)
 (import chicken.process-context)
 (import chicken.pathname)
@@ -31,10 +32,13 @@
                      "-include-path" ,(lpath "eggs") "-include-path" ,(lpath "sys")))
 
 (define (cflags) `("-c" "-fno-strict-aliasing" "-fwrapv" "-DHAVE_CHICKEN_CONFIG_H" "-DC_ENABLE_PTABLES"
-                   "-O2" "-fomit-frame-pointer" "-fPIC" "-DPIC" "-I/usr/include/chicken"))
+                   "-O2" "-fomit-frame-pointer" "-fPIC" "-DPIC"
+                   ,(string-append "-I" (foreign-value C_TARGET_INCLUDE_HOME c-string))))
 
 (define (ldflags) `(,@(ld-lpaths "-L") "-L/usr/lib" "-L/usr/local/lib"
-                    ,@(ld-lpaths "-Wl,-R") "-Wl,-R/usr/lib" "-Wl,-R/usr/local/lib"))
+                    ,@(ld-lpaths "-Wl,-R") "-Wl,-R/usr/lib" "-Wl,-R/usr/local/lib"
+                    ,(string-append "-L" (foreign-value C_TARGET_LIB_HOME c-string))
+                    ,(string-append "-Wl,-R" (foreign-value C_TARGET_LIB_HOME c-string))))
 
 (define module->unit symbol->string)
 


### PR DESCRIPTION
This just allows pontiff to work when CHICKEN is installed somewhere other than `/usr`.

Note that this bakes the include and library paths in at build time, which may not be what you want (you could grab them from `csc -cflags` or something like that instead). But, at least it works to remove the hardcoded paths. Other than these two things (and the `-s` flag on `chicken-install`, but I left that alone) the project works here.